### PR TITLE
Allow text subjects

### DIFF
--- a/lib/panoptes-subject-uploader.iced
+++ b/lib/panoptes-subject-uploader.iced
@@ -137,7 +137,7 @@ for file in args._
       # Locations array has been transformed into [{"mime type": "URL to upload"}]
       for location, ii in subject.locations
         for type, url of location
-          headers = {'Content-Type': type}
+          headers = {'Content-Type': mime.lookup imageFileNames[ii]}
           body = fs.readFileSync imageFileNames[ii]
 
           await request.put {headers, url, body}, defer error, response

--- a/lib/panoptes-subject-uploader.iced
+++ b/lib/panoptes-subject-uploader.iced
@@ -22,7 +22,7 @@ getMetadata = (rawData) ->
 findImages = (searchDir, metadata) ->
   imageFiles = []
   for key, value of metadata
-    imageFileName = value.match?(/([^\/]+\.(?:jpg|png))/i)?[1]
+    imageFileName = value.match?(/([^\/]+\.(?:jpg|png|txt))/i)?[1]
     if imageFileName?
       existingImageFile = glob.sync(path.resolve searchDir, imageFileName.replace /\W/g, '?')[0]
       if existingImageFile? and  existingImageFile not in imageFiles

--- a/lib/panoptes-subject-uploader.iced
+++ b/lib/panoptes-subject-uploader.iced
@@ -75,8 +75,11 @@ unless args.password? then await promptly.password 'Password', defer error, args
 unless args.project? then await promptly.prompt 'Project ID', defer error, args.project
 unless args.workflow? then await promptly.prompt 'Workflow ID', defer error, args.workflow
 
-await Panoptes.auth.signIn(display_name: args.username, password: args.password).then(defer user).catch(console.error.bind console)
+await Panoptes.auth.signIn(login: args.username, password: args.password).then(defer user).catch(console.error.bind console)
 log "Signed in #{user.id} (#{user.display_name})"
+
+Panoptes.api.update 'params.admin' : user.admin
+log "Setting admin flag #{user.admin}"
 
 await Panoptes.api.type('projects').get("#{args.project}").then(defer project).catch(console.error.bind console)
 log "Got project #{project.id} (#{project.display_name})"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "iced-coffee-script": "^1.8.0-d",
     "mime": "^1.3.4",
     "minimist": "^1.1.1",
-    "panoptes": "zooniverse/Panoptes-Front-End#stargazing",
+    "panoptes": "zooniverse/Panoptes-Front-End",
     "promptly": "^0.2.1",
     "request": "^2.53.0",
     "xmlhttprequest-cookie": "^0.9.2"


### PR DESCRIPTION
Uses latest Panoptes Front End.
Fixes a bug with assigning the wrong mime type to uploaded files.
Adds .txt to the allowed file extensions.
Sets the admin flag to bypass Panoptes content-type restrictions.
