### PR TITLE
Only push subject ids to array if creation is successful

### DIFF
--- a/lib/panoptes-subject-uploader.iced
+++ b/lib/panoptes-subject-uploader.iced
@@ -145,6 +145,7 @@ for file in args._
           if response?
             if 200 <= response.statusCode < 400
               log "Uploaded image #{imageFileNames[ii]}"
+              newSubjectIDs.push subject.id
             else
               error = response.body
 
@@ -153,8 +154,6 @@ for file in args._
             console.error "!!! Deleting subject #{subject.id}"
             await subject.delete().then(defer _).catch(console.error.bind console)
             break
-
-      newSubjectIDs.push subject.id
 
 if newSubjectIDs.length is 0
   log 'No subjects to link'


### PR DESCRIPTION
I ran into an issue of a couple of subjects that failed to PUT the image file. The subject was deleted on error, but the id still ended up in the subject id array. Then, the subject set creation failed because an id of a subject that didn't exist was a part of the array. This just moves the array push to only happen with successful subject creation.

For future development, I opened an issue, #8, for creating an error log when they happen. Logging the terminal session is sufficient for now, though. 
