### PR TITLE
skip-media-upload option to resolve #7

### DIFF
--- a/lib/panoptes-subject-uploader.iced
+++ b/lib/panoptes-subject-uploader.iced
@@ -43,7 +43,6 @@ locationCreator = (mimeType, url) ->
   location[mimeType] = url
   location
 
-
 createSubject = (subjectData) ->
   return if ( !subjectData || !subjectData instanceof Object )
   subject = apiClient.type('subjects').create(subjectData)
@@ -86,7 +85,7 @@ if args.help or args._.length is 0
       --subject-set "345"         If omitted, a new subject set is created
       --skip 50                   Skip the first N lines (per manifest file)
       --limit 100                 Only create N subjects (per manifest file)
-      --skip-media-upload         Default to false. Designates a supplied url for each subject, instead of uploading an image.
+      --skip-media-upload         Defaults to false. If set to true, subjects will be created using the urls provided in each row without uploading the associated media.
 
     Notes:
       Multiple manifests will end up in the same subject set.

--- a/lib/panoptes-subject-uploader.iced
+++ b/lib/panoptes-subject-uploader.iced
@@ -25,7 +25,7 @@ findImagesFiles = (searchDir, metadata) ->
     imageFileName = value.match?(/([^\/]+\.(?:jpg|jpeg|gif|png|svg|mp4|txt))/i)?[1]
     if imageFileName?
       existingImageFile = glob.sync(path.resolve searchDir, imageFileName.replace /\W/g, '?')[0]
-      if existingImageFile? and  existingImageFile not in imageFiles
+      if existingImageFile? and existingImageFile not in imageFiles
         imageFiles.push existingImageFile
   imageFiles
 
@@ -42,13 +42,6 @@ locationCreator = (mimeType, url) ->
   location = {}
   location[mimeType] = url
   location
-
-createSubject = (subjectData) ->
-  return if ( !subjectData or !subjectData instanceof Object )
-  subject = apiClient.type('subjects').create(subjectData)
-  await subject.save().then(defer _).catch(console.error.bind console)
-  log "Saved subject #{subject.id}"
-  subject
 
 argOpts =
   alias:

--- a/lib/panoptes-subject-uploader.iced
+++ b/lib/panoptes-subject-uploader.iced
@@ -32,8 +32,8 @@ findImagesFiles = (searchDir, metadata) ->
 findImagesURLs = (metadata) ->
   imageURLs = []
   for key, value of metadata
-    httpsRegexPattern = new RegExp("^(http|https)://", "i")
-    fileRegexPattern = new RegExp("([^\/]+\.(?:jpg|jpeg|gif|png|svg|mp4|txt))$", "i")
+    httpsRegexPattern = /^(https):\/\//i
+    fileRegexPattern = /([^\/]+.(?:jpg|jpeg|gif|png|svg|mp4|txt))$/i
     if httpsRegexPattern.test(value) and fileRegexPattern.test(value)
       imageURLs.push value
   imageURLs

--- a/lib/panoptes-subject-uploader.iced
+++ b/lib/panoptes-subject-uploader.iced
@@ -34,7 +34,7 @@ findImagesURLs = (metadata) ->
   for key, value of metadata
     httpsRegexPattern = new RegExp("^(http|https)://", "i")
     fileRegexPattern = new RegExp("([^\/]+\.(?:jpg|jpeg|gif|png|svg|mp4|txt))$", "i")
-    if httpsRegexPattern.test(value) && fileRegexPattern.test(value)
+    if httpsRegexPattern.test(value) and fileRegexPattern.test(value)
       imageURLs.push value
   imageURLs
 
@@ -44,7 +44,7 @@ locationCreator = (mimeType, url) ->
   location
 
 createSubject = (subjectData) ->
-  return if ( !subjectData || !subjectData instanceof Object )
+  return if ( !subjectData or !subjectData instanceof Object )
   subject = apiClient.type('subjects').create(subjectData)
   await subject.save().then(defer _).catch(console.error.bind console)
   log "Saved subject #{subject.id}"
@@ -155,7 +155,7 @@ for file in args._
         log "!!! Cannot find a https url for row #{i + 1}"
         break
       
-      for url, url in imageURLs
+      for url, index in imageURLs
         await request url, defer error, response
         
         if error?
@@ -163,7 +163,7 @@ for file in args._
           break
         
         if response?
-          if response.statusCode == 200
+          if response.statusCode is 200
             mimeType = mime.lookup url
             subject.locations.push locationCreator(mimeType, url)              
             

--- a/lib/panoptes-subject-uploader.iced
+++ b/lib/panoptes-subject-uploader.iced
@@ -19,7 +19,7 @@ getMetadata = (rawData) ->
     metadata[key.trim()] = value.trim?() ? value
   metadata
 
-findImages = (searchDir, metadata) ->
+findImagesFiles = (searchDir, metadata) ->
   imageFiles = []
   for key, value of metadata
     imageFileName = value.match?(/([^\/]+\.(?:jpg|jpeg|gif|png|svg|mp4|txt))/i)?[1]
@@ -29,6 +29,28 @@ findImages = (searchDir, metadata) ->
         imageFiles.push existingImageFile
   imageFiles
 
+findImagesURLs = (metadata) ->
+  imageURLs = []
+  for key, value of metadata
+    httpsRegexPattern = new RegExp("^(http|https)://", "i")
+    fileRegexPattern = new RegExp("([^\/]+\.(?:jpg|jpeg|gif|png|svg|mp4|txt))$", "i")
+    if httpsRegexPattern.test(value) && fileRegexPattern.test(value)
+      imageURLs.push value
+  imageURLs
+
+locationCreator = (mimeType, url) ->
+  location = {}
+  location[mimeType] = url
+  location
+
+
+createSubject = (subjectData) ->
+  return if ( !subjectData || !subjectData instanceof Object )
+  subject = apiClient.type('subjects').create(subjectData)
+  await subject.save().then(defer _).catch(console.error.bind console)
+  log "Saved subject #{subject.id}"
+  subject
+
 argOpts =
   alias:
     u: 'username'
@@ -36,6 +58,7 @@ argOpts =
     r: 'project'
     w: 'workflow'
     'subject-set': 'subjectSet'
+    'skip-media-upload': 'skipMediaUpload'
     h: 'help'
 
   default:
@@ -63,6 +86,7 @@ if args.help or args._.length is 0
       --subject-set "345"         If omitted, a new subject set is created
       --skip 50                   Skip the first N lines (per manifest file)
       --limit 100                 Only create N subjects (per manifest file)
+      --skip-media-upload         Default to false. Designates a supplied url for each subject, instead of uploading an image.
 
     Notes:
       Multiple manifests will end up in the same subject set.
@@ -118,42 +142,84 @@ for file in args._
     log "On row #{i + 1} of #{rows.length}"
 
     metadata = getMetadata row
-    imageFileNames = findImages path.dirname(file), metadata
+    
+    if args.skipMediaUpload
 
-    if imageFileNames.length is 0
-      console.error "!!! Couldn't find an image for row #{i + 1}"
+      subject = {}
+      subject.metadata = metadata
+      subject.locations = []
+      subject.links = project: args.project
 
-    else
-      subject = apiClient.type('subjects').create
-        # Locations are sent as a list of mime types.
-        locations: (mime.lookup imageFileName for imageFileName in imageFileNames)
-        metadata: metadata
-        links:
-          project: args.project
-
-      await subject.save().then(defer _).catch(console.error.bind console)
-      log "Saved subject #{subject.id}"
-
-      # Locations array has been transformed into [{"mime type": "URL to upload"}]
-      for location, ii in subject.locations
-        for type, url of location
-          headers = {'Content-Type': mime.lookup imageFileNames[ii]}
-          body = fs.readFileSync imageFileNames[ii]
-
-          await request.put {headers, url, body}, defer error, response
-
-          if response?
-            if 200 <= response.statusCode < 400
-              log "Uploaded image #{imageFileNames[ii]}"
-              newSubjectIDs.push subject.id
+      # find a https urls for the row
+      imageURLs = findImagesURLs metadata
+      if imageURLs.length is 0
+        log "!!! Cannot find a https url for row #{i + 1}"
+        break
+      
+      for url, url in imageURLs
+        await request url, defer error, response
+        
+        if error?
+          log "!!! Error requesting URL for row #{i + 1}:", error
+          break
+        
+        if response?
+          if response.statusCode == 200
+            mimeType = mime.lookup url
+            subject.locations.push locationCreator(mimeType, url)              
+            
+            newSubject = apiClient.type('subjects').create(subject)
+            await newSubject.save().then(defer _).catch(console.error.bind console)
+            log "Saved subject #{newSubject.id}"
+            
+            if newSubject?
+              newSubjectIDs.push newSubject.id
             else
-              error = response.body
-
-          if error?
-            console.error '!!! Failed to put image', error
-            console.error "!!! Deleting subject #{subject.id}"
-            await subject.delete().then(defer _).catch(console.error.bind console)
+              log "!!! Error: No subject created."
+            
+          else
+            log "!!! Error: Unexpected response code:", response.statusCode
             break
+
+
+    # create subject with media upload
+    else
+      imageFileNames = findImagesFiles path.dirname(file), metadata
+
+      if imageFileNames.length is 0
+        console.error "!!! Couldn't find an image for row #{i + 1}"
+
+      else
+        subject = apiClient.type('subjects').create
+          # Locations are sent as a list of mime types.
+          locations: (mime.lookup imageFileName for imageFileName in imageFileNames)
+          metadata: metadata
+          links:
+            project: args.project
+
+        await subject.save().then(defer _).catch(console.error.bind console)
+        log "Saved subject #{subject.id}"
+
+        # Locations array has been transformed into [{"mime type": "URL to upload"}]
+        for location, ii in subject.locations
+          for type, url of location
+            headers = {'Content-Type': mime.lookup imageFileNames[ii]}
+            body = fs.readFileSync imageFileNames[ii]
+
+            await request.put {headers, url, body}, defer error, response
+
+            if response?
+              if 200 <= response.statusCode < 400
+                log "Uploaded image #{imageFileNames[ii]}"
+                newSubjectIDs.push subject.id
+              else
+                error = response.body
+
+            if error?
+              console.error '!!! Failed to put image', error
+              console.error "!!! Deleting subject #{subject.id}"
+              await subject.delete().then(defer _).catch(console.error.bind console)
+              break
 
 if newSubjectIDs.length is 0
   log 'No subjects to link'


### PR DESCRIPTION
This PR adds a `--skip-media-upload` option to resolve #7 . If this option is set to true, a subject's location will be created using the provided url(s) for each row. Before a subject is created, the script checks that the provided url:
- uses https
- uses one of the following file extensions: .jpg, .jpeg, .gif, .png, .svg, .mp4, or .txt
- responds with a 200
