### PR TITLE
Add winston logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "panoptes-client": "^2.5.1",
     "promptly": "^0.2.1",
     "request": "^2.53.0",
+    "winston": "^2.2.0",
     "xmlhttprequest-cookie": "^0.9.2"
   }
 }


### PR DESCRIPTION
Added `winston` for logging both to console and to file for #8. It's human readable to the console and also outputs json to a log file. The log file is written to the same folder that the client is run in and appends it on subsequent runs. 

I decided on winston because of its community support and extensibility. Later we may want to consider handlers for certain kind of errors, like timeouts, that I presume are coming from s3. Instead of logging, attempt the `PUT` again?

For now, the log file will make it easier to track when failures happen.

@brian-c, if you're too busy, I can reassign to @simensta since she's done work on the uploader too.
