### PR TITLE
Add retry lib

### DIFF
--- a/lib/panoptes-subject-uploader.iced
+++ b/lib/panoptes-subject-uploader.iced
@@ -4,7 +4,7 @@ minimist = require 'minimist'
 promptly = require 'promptly'
 auth = require 'panoptes-client/lib/auth'
 apiClient = require 'panoptes-client/lib/api-client'
-request = require 'request'
+request = require 'requestretry'
 path = require 'path'
 Baby = require 'babyparse'
 fs = require 'fs'
@@ -167,7 +167,7 @@ for file in args._
       subject.links = project: args.project
       imageURLs = findImagesURLs metadata
       
-      if imageURLs.length == 0
+      if imageURLs.length is 0
         log.error "!!! Couldn't find an media urls for row #{i + 1}"
       
       locationSuccessCount = 0
@@ -186,7 +186,7 @@ for file in args._
           else
             log.error "!!! Error: Unexpected response code:", response.statusCode
 
-      if locationSuccessCount == imageURLs.length
+      if locationSuccessCount is imageURLs.length
         newSubject = apiClient.type('subjects').create(subject)
         await newSubject.save().then(defer _).catch(log.error.bind console)
         log.info "Saved subject #{newSubject.id}"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "panoptes-client": "^2.5.1",
     "promptly": "^0.2.1",
     "request": "^2.53.0",
+    "requestretry": "^1.8.0",
     "winston": "^2.2.0",
     "xmlhttprequest-cookie": "^0.9.2"
   }


### PR DESCRIPTION
Since I figured this was a solved problem, I decided to find and add a library that would retry requests on error. I decided to go with [request-retry](https://github.com/FGRibreau/node-request-retry) since it covers all of the various errors I noted in #8. I didn't see any need to modify any of the default options that are added with `request-retry`. Defaults are to retry every 5s up to 5 times on 5xx or network errors. It looks like it worked:
<img width="808" alt="screen shot 2016-06-20 at 3 45 27 pm" src="https://cloud.githubusercontent.com/assets/5016731/16209973/4f79285a-36ff-11e6-9591-cc218d900608.png">
(I logged number of attempts just for testing purposes).

If this looks ok, then this should close #8.
