### PR TITLE
Fix #26 - Link successfully saved subjects to subject set

### DIFF
--- a/lib/panoptes-subject-uploader.iced
+++ b/lib/panoptes-subject-uploader.iced
@@ -189,7 +189,7 @@ for file in args._
       if locationSuccessCount isnt 0 and locationSuccessCount is imageURLs.length
         newSubject = apiClient.type('subjects').create(subject)
         await newSubject.save().then(defer _).catch(log.error.bind console)
-        log.info ">> Saved subject #{newSubject.id} for #{imageURLs}"
+        log.info "Saved subject #{newSubject.id} for #{imageURLs}"
       
       if newSubject?
         newSubjectIDs.push newSubject.id
@@ -212,7 +212,7 @@ for file in args._
             project: args.project
 
         await subject.save().then(defer _).catch(log.error.bind console)
-        log.info ">> Saved subject #{newSubject.id} for #{imageURLs}"
+        log.info "Saved subject #{newSubject.id} for #{imageURLs}"
 
         # Locations array has been transformed into [{"mime type": "URL to upload"}]
         successCount = 0

--- a/lib/panoptes-subject-uploader.iced
+++ b/lib/panoptes-subject-uploader.iced
@@ -160,7 +160,7 @@ for file in args._
     metadata = getMetadata row
     
     if args.skipMediaUpload
-
+      newSubject = null
       subject = {}
       subject.metadata = metadata
       subject.locations = []
@@ -186,10 +186,10 @@ for file in args._
           else
             log.error "!!! Error: Unexpected response code:", response.statusCode
 
-      if locationSuccessCount is imageURLs.length
+      if locationSuccessCount isnt 0 and locationSuccessCount is imageURLs.length
         newSubject = apiClient.type('subjects').create(subject)
         await newSubject.save().then(defer _).catch(log.error.bind console)
-        log.info "Saved subject #{newSubject.id}"
+        log.info ">> Saved subject #{newSubject.id} for #{imageURLs}"
       
       if newSubject?
         newSubjectIDs.push newSubject.id
@@ -212,7 +212,7 @@ for file in args._
             project: args.project
 
         await subject.save().then(defer _).catch(log.error.bind console)
-        log.info "Saved subject #{subject.id}"
+        log.info ">> Saved subject #{newSubject.id} for #{imageURLs}"
 
         # Locations array has been transformed into [{"mime type": "URL to upload"}]
         successCount = 0


### PR DESCRIPTION
Under the condition of --skip-media-upload=true, successfully saved subjects should now be linked to the subject set regardless of any unsuccessfully saved subjects. Fixes #26. 
